### PR TITLE
feat: arm build

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -19,8 +19,8 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-#          - os: ubuntu-24.04-arm
-#            target: aarch64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
           - os: macos-latest
             target: x86_64-apple-darwin
           - os: macos-latest

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -79,5 +79,6 @@ jobs:
         with:
           files: |
             sm-x86_64-unknown-linux-gnu.zip
+            sm-aarch64-unknown-linux-gnu.zip
             sm-x86_64-apple-darwin.zip
             sm-aarch64-apple-darwin.zip

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,7 +359,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ resolver = "2"
 
 [workspace.package]
 description = "Teton's Fleet Management System. It provides automation to easily deploy and monitor applications at scale."
-version = "0.2.0"
+version = "0.2.1"
+edition = "2024"
 
 repository = "https://github.com/teton-ai/smith"
 authors = [

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "api"
 version = "0.1.0"
-description.workspace = true
-license.workspace = true
+edition.workspace = true
 repository.workspace = true
 authors.workspace = true
+license.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cli"
-edition = "2024"
-description = "Smith Command Line Interface (CLI)"
 version.workspace = true
+description = "Smith Command Line Interface (CLI)"
+edition.workspace = true
 repository.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
runner was only available for public repos, adding build now that is public.
https://github.com/actions/partner-runner-images/tree/main?tab=readme-ov-file#available-images